### PR TITLE
Fixing links on the Secure computation and storage page

### DIFF
--- a/secure-computing/README.md
+++ b/secure-computing/README.md
@@ -2,8 +2,8 @@
 
 The tools presented in this section are tools that can help you keep your research data safe during storage and computation:
 
-- The [encryption tools](encryption.md) listed in our overview can encrypt files, folders and/or drives while data are stored ("at rest"). You can read more about encryption in the [encryption section of the Data Privacy Handbook](https://utrechtuniversity.github.io/dataprivacyhandbook/encryption.html)
-- The [secure computing tools](secure-computing.md) are software, frameworks, or communities for keeping data safe in the analysis phase of a project. For more information on secure computation, see the [Secure computation chapter in the Data Privacy Handbook](https://utrechtuniversity.github.io/dataprivacyhandbook/secure-computation.html).
+- The [encryption tools](encryption-tools.md) listed in our overview can encrypt files, folders and/or drives while data are stored ("at rest"). You can read more about encryption in the [encryption section of the Data Privacy Handbook](https://utrechtuniversity.github.io/dataprivacyhandbook/encryption.html)
+- The [secure computing tools](secure-computing-tools.md) are software, frameworks, or communities for keeping data safe in the analysis phase of a project. For more information on secure computation, see the [Secure computation chapter in the Data Privacy Handbook](https://utrechtuniversity.github.io/dataprivacyhandbook/secure-computation.html).
 
 ## Tools/techniques not included
 


### PR DESCRIPTION
I was clicking around and noticed that the links on the Secure computation and storage page were dead (for the encryption tools and the secure computing tools)

This PR fixes the dead links.

Again, I'm creating a PR off the bat, believing that it's a straightforward fix. ✌️ 