### PR TITLE
Add a GitHub page?

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true
+include:
+  - README.md
+  - LICENSE.md


### PR DESCRIPTION
This PR is a suggestion to add a GitHub page to this repo. 

I keep coming back to this repo, and I thought it'd be a nice idea to read it in a website format (aside from on the GitHub UI). To do so, I followed this Easy Markdown guide to add a _config.yml file:

https://nicolas-van.github.io/easy-markdown-to-github-pages/


The page for my fork is available here:
https://nsunami.github.io/privacy-engineering-tools/

I think things are rendering nicely, including the tables:

![image](https://github.com/user-attachments/assets/d0ada236-005d-4380-854b-226032553b2f)


(If this PR is to be merged, the admin of this repo needs to turn on the GitHub page function via repo setting. )


Just a suggestion! 